### PR TITLE
Updated submodule and .error function

### DIFF
--- a/js/app/community-edition.js
+++ b/js/app/community-edition.js
@@ -288,7 +288,7 @@ main.page = function() {
                                 var getSvyUrlBase = $.get(config.actions, function(a){
 									actionUrls = a;
 									  })
-								  .error(function(jqXHR, textStatus, errorThrown){
+								  .fail(function(jqXHR, textStatus, errorThrown){
 									console.log("Error getting survey urls!!");//Need to fill in!!
 								  })
                                 


### PR DESCRIPTION
This commit pulls the latest of the core submodule. It also updates the jQuery .error() function to .fail() (see https://api.jquery.com/jquery.get/ which says "_The jqXHR.success(), jqXHR.error(), and jqXHR.complete() callback methods are removed as of jQuery 3.0. You can use jqXHR.done(), jqXHR.fail(), and jqXHR.always() instead._")